### PR TITLE
fix(xml): 修正data字段写回位置

### DIFF
--- a/tests/test_update_symbols.py
+++ b/tests/test_update_symbols.py
@@ -12,14 +12,14 @@ import update_symbols
 
 XML_TEXT = """
 <kphdyn>
-  <data id="1" arch="amd64" file="ntoskrnl.exe" version="10.0.1" timestamp="0" size="0" sha256="abc" fields="0" />
+  <data id="1" arch="amd64" file="ntoskrnl.exe" version="10.0.1" timestamp="0" size="0" sha256="abc">0</data>
   <fields id="1" EpObjectTable="0x570" />
 </kphdyn>
 """
 
 HASH_XML_TEXT = """
 <kphdyn>
-  <data id="1" arch="amd64" file="ntoskrnl.exe" version="10.0.1" timestamp="0x10" size="0x20" hash="abc" fields="0" />
+  <data id="1" arch="amd64" file="ntoskrnl.exe" version="10.0.1" timestamp="0x10" size="0x20" hash="abc">0</data>
   <fields id="1" EpObjectTable="0x570" />
 </kphdyn>
 """
@@ -620,7 +620,8 @@ class TestUpdateSymbols(unittest.TestCase):
                 update_symbols.export_xml(tree, config, Path(temp_dir))
 
         data_elem = tree.getroot().find("data")
-        self.assertEqual("1", data_elem.get("fields"))
+        self.assertEqual("1", data_elem.text)
+        self.assertIsNone(data_elem.get("fields"))
 
     def test_export_xml_ignores_yaml_without_symbol_spec(self) -> None:
         tree = update_symbols.ET.ElementTree(update_symbols.ET.fromstring(XML_TEXT))
@@ -672,7 +673,8 @@ class TestUpdateSymbols(unittest.TestCase):
         data_elems = tree.getroot().findall("data")
         self.assertEqual(1, len(data_elems))
         self.assertEqual("abc", data_elems[0].get("hash"))
-        self.assertEqual("1", data_elems[0].get("fields"))
+        self.assertEqual("1", data_elems[0].text)
+        self.assertIsNone(data_elems[0].get("fields"))
 
     def test_export_xml_creates_data_entry_with_required_metadata(self) -> None:
         tree = update_symbols.ET.ElementTree(update_symbols.ET.fromstring("<kphdyn />"))
@@ -698,4 +700,37 @@ class TestUpdateSymbols(unittest.TestCase):
         self.assertEqual("abc", data_elem.get("hash"))
         self.assertEqual("0x123", data_elem.get("timestamp"))
         self.assertEqual("0x456", data_elem.get("size"))
-        self.assertEqual("1", data_elem.get("fields"))
+        self.assertEqual("1", data_elem.text)
+        self.assertIsNone(data_elem.get("fields"))
+
+    def test_export_xml_removes_stale_fields_attribute(self) -> None:
+        tree = update_symbols.ET.ElementTree(
+            update_symbols.ET.fromstring(
+                """
+<kphdyn>
+  <data arch="amd64" file="ntoskrnl.exe" version="10.0.1" hash="abc" fields="0">0</data>
+  <fields id="1" EpObjectTable="0x570" />
+</kphdyn>
+"""
+            )
+        )
+        config = self._build_config()
+
+        with TemporaryDirectory() as temp_dir:
+            sha_dir = Path(temp_dir) / "amd64" / "ntoskrnl.exe.10.0.1" / "abc"
+            sha_dir.mkdir(parents=True, exist_ok=True)
+            (sha_dir / "EpObjectTable.yaml").write_text(
+                "category: struct_offset\noffset: 0x570\n",
+                encoding="utf-8",
+            )
+            with patch.object(
+                update_symbols,
+                "_load_binary_metadata",
+                return_value={"timestamp": "0x123", "size": "0x456"},
+                create=True,
+            ):
+                update_symbols.export_xml(tree, config, Path(temp_dir))
+
+        data_elem = tree.getroot().find("data")
+        self.assertEqual("1", data_elem.text)
+        self.assertIsNone(data_elem.get("fields"))

--- a/update_symbols.py
+++ b/update_symbols.py
@@ -381,7 +381,7 @@ def _ensure_data_entry(
     data_elem.set("sha256", sha256)
     data_elem.set("timestamp", metadata["timestamp"])
     data_elem.set("size", metadata["size"])
-    data_elem.set("fields", "0")
+    data_elem.text = "0"
     return data_elem
 
 
@@ -404,7 +404,8 @@ def export_xml(tree: ET.ElementTree, config: Any, symboldir: Path) -> ET.Element
                         data_elem = _ensure_data_entry(
                             root, arch, module_path, version, sha_dir.name, metadata
                         )
-                        data_elem.set("fields", fields_id)
+                        data_elem.text = fields_id
+                        data_elem.attrib.pop("fields", None)
     return tree
 
 


### PR DESCRIPTION
## Summary
- 修正 `update_symbols.py` 导出逻辑，将 fields id 写回 `<data>` 元素文本而不是 `fields` 属性
- 新建 `<data>` 条目时沿用既有 XML 契约，默认文本为 `0`
- 更新并新增回归测试，覆盖旧 `fields` 属性清理和文本写回行为

## Test Plan
- python -m unittest tests.test_update_symbols.TestUpdateSymbols.test_export_xml_reuses_existing_fields_id tests.test_update_symbols.TestUpdateSymbols.test_export_xml_reuses_existing_data_entry_with_hash_attribute tests.test_update_symbols.TestUpdateSymbols.test_export_xml_creates_data_entry_with_required_metadata tests.test_update_symbols.TestUpdateSymbols.test_export_xml_removes_stale_fields_attribute
- 定向探针验证 `symbols/amd64/ntoskrnl.exe.10.0.22621.3668/...` 加载 46 个 YAML 后写回 `data_text=34`，且 `data_fields_attr=None`