### PR TITLE
修正 fields 字段输出格式

### DIFF
--- a/tests/test_update_symbols.py
+++ b/tests/test_update_symbols.py
@@ -13,14 +13,18 @@ import update_symbols
 XML_TEXT = """
 <kphdyn>
   <data id="1" arch="amd64" file="ntoskrnl.exe" version="10.0.1" timestamp="0" size="0" sha256="abc">0</data>
-  <fields id="1" EpObjectTable="0x570" />
+  <fields id="1">
+    <field value="0x0570" name="EpObjectTable" />
+  </fields>
 </kphdyn>
 """
 
 HASH_XML_TEXT = """
 <kphdyn>
   <data id="1" arch="amd64" file="ntoskrnl.exe" version="10.0.1" timestamp="0x10" size="0x20" hash="abc">0</data>
-  <fields id="1" EpObjectTable="0x570" />
+  <fields id="1">
+    <field value="0x0570" name="EpObjectTable" />
+  </fields>
 </kphdyn>
 """
 
@@ -623,6 +627,73 @@ class TestUpdateSymbols(unittest.TestCase):
         self.assertEqual("1", data_elem.text)
         self.assertIsNone(data_elem.get("fields"))
 
+    def test_export_xml_creates_fields_as_field_children(self) -> None:
+        tree = update_symbols.ET.ElementTree(update_symbols.ET.fromstring("<kphdyn />"))
+        config = SimpleNamespace(
+            modules=[
+                SimpleNamespace(
+                    name="ntoskrnl",
+                    path=["ntoskrnl.exe"],
+                    symbols=[
+                        SimpleNamespace(
+                            name="EgeGuid",
+                            category="struct_offset",
+                            data_type="uint16",
+                        ),
+                        SimpleNamespace(
+                            name="EpObjectTable",
+                            category="struct_offset",
+                            data_type="uint16",
+                        ),
+                        SimpleNamespace(
+                            name="CmpEnumerateCallback",
+                            category="gv",
+                            data_type="uint32",
+                        ),
+                    ],
+                )
+            ]
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            sha_dir = Path(temp_dir) / "amd64" / "ntoskrnl.exe.10.0.1" / "abc"
+            sha_dir.mkdir(parents=True, exist_ok=True)
+            (sha_dir / "EgeGuid.yaml").write_text(
+                "category: struct_offset\noffset: 0x28\n",
+                encoding="utf-8",
+            )
+            (sha_dir / "EpObjectTable.yaml").write_text(
+                "category: struct_offset\noffset: 0x300\n",
+                encoding="utf-8",
+            )
+            (sha_dir / "CmpEnumerateCallback.yaml").write_text(
+                "category: gv\ngv_rva: 0x7d07f0\n",
+                encoding="utf-8",
+            )
+            with patch.object(
+                update_symbols,
+                "_load_binary_metadata",
+                return_value={"timestamp": "0x0", "size": "0x0"},
+            ):
+                update_symbols.export_xml(tree, config, Path(temp_dir))
+
+        fields_elem = tree.getroot().find("fields")
+        self.assertEqual({"id": "1"}, fields_elem.attrib)
+        self.assertEqual("\n        ", fields_elem.text)
+        self.assertEqual("\n", fields_elem.tail)
+        self.assertEqual(
+            [
+                [("value", "0x0028"), ("name", "EgeGuid")],
+                [("value", "0x0300"), ("name", "EpObjectTable")],
+                [("value", "0x7d07f0"), ("name", "CmpEnumerateCallback")],
+            ],
+            [list(field.attrib.items()) for field in fields_elem.findall("field")],
+        )
+        self.assertEqual(
+            ["\n        ", "\n        ", "\n    "],
+            [field.tail for field in fields_elem.findall("field")],
+        )
+
     def test_export_xml_ignores_yaml_without_symbol_spec(self) -> None:
         tree = update_symbols.ET.ElementTree(update_symbols.ET.fromstring(XML_TEXT))
         config = self._build_config()
@@ -648,8 +719,11 @@ class TestUpdateSymbols(unittest.TestCase):
                 update_symbols.export_xml(tree, config, Path(temp_dir))
 
         fields_elem = tree.getroot().find("fields")
-        self.assertEqual("0x570", fields_elem.get("EpObjectTable"))
-        self.assertIsNone(fields_elem.get("NtSecureConnectPort"))
+        self.assertIsNone(fields_elem.get("EpObjectTable"))
+        self.assertEqual(
+            [[("value", "0x0570"), ("name", "EpObjectTable")]],
+            [list(field.attrib.items()) for field in fields_elem.findall("field")],
+        )
 
     def test_export_xml_reuses_existing_data_entry_with_hash_attribute(self) -> None:
         tree = update_symbols.ET.ElementTree(update_symbols.ET.fromstring(HASH_XML_TEXT))

--- a/update_symbols.py
+++ b/update_symbols.py
@@ -313,12 +313,35 @@ def _collect_existing_fields(root: ET.Element) -> dict[tuple[tuple[str, int], ..
     existing: dict[tuple[tuple[str, int], ...], str] = {}
     for fields_elem in root.findall("fields"):
         values = []
-        for key, value in fields_elem.attrib.items():
-            if key == "id":
-                continue
-            values.append((key, int(value, 16)))
+        field_children = fields_elem.findall("field")
+        if field_children:
+            for field_elem in field_children:
+                name = field_elem.get("name")
+                value = field_elem.get("value")
+                if name is None or value is None:
+                    continue
+                values.append((name, int(value, 16)))
+        else:
+            for key, value in fields_elem.attrib.items():
+                if key == "id":
+                    continue
+                values.append((key, int(value, 16)))
         existing[tuple(sorted(values))] = fields_elem.get("id", "0")
     return existing
+
+
+def _format_field_value(value: int) -> str:
+    return f"0x{value:04x}"
+
+
+def _append_fields_element(root: ET.Element, fields_id: int) -> ET.Element:
+    if len(root):
+        root[-1].tail = "\n    "
+    fields_elem = ET.SubElement(root, "fields")
+    fields_elem.set("id", str(fields_id))
+    fields_elem.text = "\n        "
+    fields_elem.tail = "\n"
+    return fields_elem
 
 
 def _find_or_create_fields_id(root: ET.Element, values: dict[str, int]) -> str:
@@ -329,10 +352,14 @@ def _find_or_create_fields_id(root: ET.Element, values: dict[str, int]) -> str:
         return matched
 
     next_id = max([0] + [int(elem.get("id", "0")) for elem in root.findall("fields")]) + 1
-    fields_elem = ET.SubElement(root, "fields")
-    fields_elem.set("id", str(next_id))
-    for name, value in sorted(values.items()):
-        fields_elem.set(name, hex(value))
+    fields_elem = _append_fields_element(root, next_id)
+    for name, value in values.items():
+        field_elem = ET.SubElement(fields_elem, "field")
+        field_elem.set("value", _format_field_value(value))
+        field_elem.set("name", name)
+        field_elem.tail = "\n        "
+    if len(fields_elem):
+        fields_elem[-1].tail = "\n    "
     return str(next_id)
 
 


### PR DESCRIPTION
## Summary
- 将 update_symbols.py 新建 fields 改为 field 子元素格式
- 字段值输出为补零 hex，兼容读取旧 attribute 与新子元素格式
- 补充回归测试覆盖字段结构、顺序和缩进

## Test Plan
- python -m unittest tests.test_update_symbols.TestUpdateSymbols.test_export_xml_reuses_existing_fields_id tests.test_update_symbols.TestUpdateSymbols.test_export_xml_creates_fields_as_field_children tests.test_update_symbols.TestUpdateSymbols.test_export_xml_ignores_yaml_without_symbol_spec tests.test_update_symbols.TestUpdateSymbols.test_export_xml_reuses_existing_data_entry_with_hash_attribute tests.test_update_symbols.TestUpdateSymbols.test_export_xml_creates_data_entry_with_required_metadata tests.test_update_symbols.TestUpdateSymbols.test_export_xml_removes_stale_fields_attribute
- git diff --check